### PR TITLE
Bug fix for OAuth token generation in IRB console

### DIFF
--- a/bin/tumblr
+++ b/bin/tumblr
@@ -35,7 +35,7 @@ else
 
     site = "http://#{host}"
     consumer = OAuth::Consumer.new(config.consumer_key, config.consumer_secret, :site => site)
-    request_token = consumer.get_request_token :oauth_callback => 'http://localhost/'
+    request_token = consumer.get_request_token :exclude_callback => true
 
     puts
 


### PR DESCRIPTION
I had a problem generating an OAuth token using the IRB console and after some research, found [this post](https://groups.google.com/d/msg/tumblr-api/foJZZdSKO2s/IeX5DyCOtmsJ), explaining that OOB is not supported by the API. Although the API most likely never supported OOB, it seems that until recently, it didn't complain. I made a simple change to fix the issue.
