### PR TITLE
return the error reason from the response body

### DIFF
--- a/lib/tumblr/request.rb
+++ b/lib/tumblr/request.rb
@@ -43,7 +43,10 @@ module Tumblr
       if [201, 200].include?(response.status)
         response.body['response']
       else
-        response.body['meta']
+      # no doubt surfacing the error reason from the response body along with the generic code
+      # is going to save some other developer some very aggravating time discovering e.g. there's a daily
+      # photo post limit on Tumblr...
+        response.body['meta'].merge(response.body['response'])
       end
     end
 


### PR DESCRIPTION
Since the server nicely gives the reason for the error and not just the generic response code, the API wrapper should surface it to the client. Looking at the discussion forums, lots of developers have run into e.g. the daily photo post limit but this is hard to diagnose when all you get is a 400 Bad Request from the wrapper.
