### PR TITLE
uploadio + edit

### DIFF
--- a/lib/tumblr/post.rb
+++ b/lib/tumblr/post.rb
@@ -4,10 +4,13 @@ module Tumblr
   module Post
 
     STANDARD_POST_OPTIONS = [:state, :tags, :tweet, :date, :markdown, :slug, :format]
-    VALID_POST_TYPES = [:audio, :photo, :quote, :text, :link, :chat, :video]
+    DATA_POST_TYPES = [:audio, :video, :photo]
+    VALID_POST_TYPES = DATA_POST_TYPES + [:quote, :text, :link, :chat]
 
     def edit(blog_name, options = {})
       convert_source_array :source, options
+      extract_data!(options) if DATA_POST_TYPES.include?(options[:type])
+
       post(blog_path(blog_name, 'post/edit'), options)
     end
 


### PR DESCRIPTION
I made the following changes:
- allow to pass in ready made Faraday::UploadIO objects instead of just 'file paths'
- call extract_data!() when editing post types that have 'data'

Also, I added tests for both changes.
