### PR TITLE
Add compatibility with faraday 0.9.0

### DIFF
--- a/lib/tumblr/connection.rb
+++ b/lib/tumblr/connection.rb
@@ -5,7 +5,8 @@ module Tumblr
   module Connection
 
     def connection(options={})
-      
+      options = options.clone
+
       default_options = {
         :headers => {
           :accept => 'application/json',
@@ -14,7 +15,7 @@ module Tumblr
         :url => "http://#{api_host}/"
       }
 
-      client = options[:client] ||= Faraday.default_adapter
+      client = options.delete(:client) || Faraday.default_adapter
 
       Faraday.new("http://#{api_host}/", default_options.merge(options)) do |conn|
         data = { :api_host => api_host }.merge(credentials)


### PR DESCRIPTION
If I use faraday 0.9.0 I get:
`
undefined method `client=' for #<Faraday::ConnectionOptions:0x00000006f65850>
`
That's because Faraday become very strict for provided params. My fix does not include client param on Faraday initialization, so Faraday does not complains.
