### PR TITLE
Relax the version requirement for faraday_middleware

### DIFF
--- a/tumblr_client.gemspec
+++ b/tumblr_client.gemspec
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), 'lib/tumblr/version')
 
 Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.9.0'
-  gem.add_dependency 'faraday_middleware', '~> 0.9.0'
+  gem.add_dependency 'faraday_middleware', '~> 0.9'
   gem.add_dependency 'json'
   gem.add_dependency 'simple_oauth'
   gem.add_dependency 'oauth'


### PR DESCRIPTION
faraday_middleware 0.10.0 is out, and it should work fine with tumblr_client.