### PR TITLE
Correct dependencies for Ruby 1.9.3

### DIFF
--- a/tumblr_client.gemspec
+++ b/tumblr_client.gemspec
@@ -4,14 +4,14 @@ require File.join(File.dirname(__FILE__), 'lib/tumblr/version')
 Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.9.0'
   gem.add_dependency 'faraday_middleware', '~> 0.9'
-  gem.add_dependency 'json'
-  gem.add_dependency 'simple_oauth'
-  gem.add_dependency 'oauth'
-  gem.add_dependency 'mime-types'
-  gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'webmock'
-  gem.add_development_dependency 'simplecov'
+  gem.add_dependency 'json', '~> 1.8'
+  gem.add_dependency 'simple_oauth', '~> 0.3'
+  gem.add_dependency 'oauth', '~> 0.5'
+  gem.add_dependency 'mime-types', '~> 2.99'
+  gem.add_development_dependency 'rake', '~> 11.3'
+  gem.add_development_dependency 'rspec', '~> 3.5'
+  gem.add_development_dependency 'webmock', '~> 2.0'
+  gem.add_development_dependency 'simplecov', '~> 0.12'
   gem.authors = ['John Bunting', 'John Crepezzi']
   gem.description = %q{A Ruby wrapper for the Tumblr v2 API}
   gem.email = ['codingjester@gmail.com', 'john@crepezzi.com']


### PR DESCRIPTION
## What

I added some versioning for the dependencies in the gemspec. This will allow for the gem to build on Ruby 1.9.3.

### Note

I wasn't able to install Ruby 1.9.2 on macOS for whatever reason, but 1.9.2 is fairly old so I think it might be time to talk about dropping support for Ruby 1.9.2. If you feel this is appropriate, I will open up another PR to do so. 😃 

## Test

1. If you're using RVM, switch to 1.9.3: `rvm use 1.9.3` (you may need to install first with `rvm install 1.9.3`)
2. Run `bundle install` **(please see note below about the `json` gem)**
3. Try to build the gem: `gem build tumblr_client.gemspec`
4. If all goes well, the above will run without any errors!

### Note about `json` gem

If you're on a newer build of macOS, you'll need to do the following in order to build the `json` gem:

```
xcode-select --install
sudo xcodebuild -license
```