### PR TITLE
relax specificity of faraday dependencies

### DIFF
--- a/tumblr_client.gemspec
+++ b/tumblr_client.gemspec
@@ -2,8 +2,8 @@
 require File.join(File.dirname(__FILE__), 'lib/tumblr/version')
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'faraday', '~> 0.9.0'
-  gem.add_dependency 'faraday_middleware', '~> 0.9'
+  gem.add_dependency 'faraday', '~> 0.11.0'
+  gem.add_dependency 'faraday_middleware', '~> 0.11.0'
   gem.add_dependency 'json'
   gem.add_dependency 'simple_oauth'
   gem.add_dependency 'oauth'

--- a/tumblr_client.gemspec
+++ b/tumblr_client.gemspec
@@ -2,8 +2,8 @@
 require File.join(File.dirname(__FILE__), 'lib/tumblr/version')
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'faraday', '~> 0.11.0'
-  gem.add_dependency 'faraday_middleware', '~> 0.11.0'
+  gem.add_dependency 'faraday', '<= 1.0.0'
+  gem.add_dependency 'faraday_middleware', '<= 1.0.0'
   gem.add_dependency 'json'
   gem.add_dependency 'simple_oauth'
   gem.add_dependency 'oauth'


### PR DESCRIPTION
Since minor versions of `faraday` and `faraday_middleware` haven't broken this gem thus far, I think it is safe to lock them at the major version level.