### PR TITLE
Tumblr::Request#get_redirect_url sees both 301 and 302 as redirects

### DIFF
--- a/lib/tumblr/request.rb
+++ b/lib/tumblr/request.rb
@@ -14,7 +14,7 @@ module Tumblr
     # get a redirect url
     def get_redirect_url(path, params = {})
       response = get_response path, params
-      if response.status == 301
+      if [301, 302].include?(response.status)
         response.headers['Location']
       else
         response.body['meta']

--- a/spec/examples/request_spec.rb
+++ b/spec/examples/request_spec.rb
@@ -58,21 +58,25 @@ describe Tumblr::Request do
 
   describe :get_redirect_url do
 
-    context 'when redirect is found' do
+    [301, 302].each do |status|
 
-      before do
-        @path = '/the/path'
-        @params = { :hello => 'world' }
-        @redirect_url = 'redirect-to-here'
-        expect(client).to receive(:get_response).once.with(@path, @params).
-        and_return(OpenStruct.new({
-          :status => 301,
-          :headers => { 'Location' => @redirect_url }
-        }))
-      end
+      context "when redirect is found with #{status} code" do
 
-      it 'should return the redirect url' do
-        expect(client.get_redirect_url(@path, @params)).to eq(@redirect_url)
+        before do
+          @path = '/the/path'
+          @params = { :hello => 'world' }
+          @redirect_url = 'redirect-to-here'
+          expect(client).to receive(:get_response).once.with(@path, @params).
+          and_return(OpenStruct.new({
+            :status => status,
+            :headers => { 'Location' => @redirect_url }
+          }))
+        end
+
+        it 'should return the redirect url' do
+          expect(client.get_redirect_url(@path, @params)).to eq(@redirect_url)
+        end
+
       end
 
     end


### PR DESCRIPTION
Allow 302 which is now being returned by the Tumblr API for the avatar endpoint.