### PR TITLE
Add recent API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ coverage
 Gemfile.lock
 
 .bundle
+
+*.env*
+_init_client.rb

--- a/lib/tumblr/blog.rb
+++ b/lib/tumblr/blog.rb
@@ -120,10 +120,11 @@ module Tumblr
       post(blog_path(blocker_blog, 'blocks'), options)
     end
 
-    # Unlock a blog (blockee_blog) from blocker_blog (if authorized)
+    # Unblock a blog (blockee_blog) from blocker_blog (if authorized)
     def unblock(blocker_blog, blockee_blog=nil, **options)
       validate_options([:blocked_tumblelog, :anonymous_only], options)
       options[:blocked_tumblelog] ||= blockee_blog
+      puts "#{{path: blog_path(blocker_blog, 'blocks'), options: options}}"
       delete(blog_path(blocker_blog, 'blocks'), options)
     end
 

--- a/lib/tumblr/blog.rb
+++ b/lib/tumblr/blog.rb
@@ -19,11 +19,20 @@ module Tumblr
       get(blog_path(blog_name, 'followers'), options)
     end
 
-    # Gets the list of blogs the user is following, if possible
+    # Gets the list of blogs the user is following
     def blog_following(blog_name, options = {})
       validate_options([:limit, :offset], options)
       get(blog_path(blog_name, 'following'), options)
     end
+
+    # Determines whether own blog (followee_blog) is followed by follower_blog 
+    # (if authorized)
+    def followed_by(followee_blog, follower_blog=nil, **options)
+      validate_options([:query], options)
+      options[:query] ||= follower_blog
+      get(blog_path(followee_blog, 'followed_by'), options)
+    end
+    alias_method :blog_followed_by, :followed_by
 
     # Gets the list of likes for the blog
     def blog_likes(blog_name, options = {})
@@ -105,14 +114,14 @@ module Tumblr
     alias_method :blocked, :blocks
 
     # Block a blog (blockee_blog) from blocker_blog (if authorized)
-    def block(blocker_blog, blockee_blog=nil, options = {})
+    def block(blocker_blog, blockee_blog=nil, **options)
       validate_options([:blocked_tumblelog, :post_id], options)
       options[:blocked_tumblelog] ||= blockee_blog
       post(blog_path(blocker_blog, 'blocks'), options)
     end
 
     # Unlock a blog (blockee_blog) from blocker_blog (if authorized)
-    def unblock(blocker_blog, blockee_blog=nil, options = {})
+    def unblock(blocker_blog, blockee_blog=nil, **options)
       validate_options([:blocked_tumblelog, :anonymous_only], options)
       options[:blocked_tumblelog] ||= blockee_blog
       delete(blog_path(blocker_blog, 'blocks'), options)

--- a/lib/tumblr/blog.rb
+++ b/lib/tumblr/blog.rb
@@ -57,7 +57,7 @@ module Tumblr
     end
 
     # Get post of given ID from blog
-    def get_post(blog_name, post_id, options = {})
+    def get_post(blog_name, post_id, **options)
       validate_options([:post_format], options)
       get(blog_path(blog_name, "posts/#{post_id}"), options)
     end

--- a/lib/tumblr/blog.rb
+++ b/lib/tumblr/blog.rb
@@ -19,6 +19,12 @@ module Tumblr
       get(blog_path(blog_name, 'followers'), options)
     end
 
+    # Gets the list of blogs the user is following, if possible
+    def blog_following(blog_name, options = {})
+      validate_options([:limit, :offset], options)
+      get(blog_path(blog_name, 'following'), options)
+    end
+
     # Gets the list of likes for the blog
     def blog_likes(blog_name, options = {})
       validate_options([:limit, :offset, :before, :after], options)
@@ -29,6 +35,7 @@ module Tumblr
       get(url, params)
     end
 
+    # Get public posts from blog
     def posts(blog_name, options = {})
       url = blog_path(blog_name, 'posts')
       if options.has_key?(:type)
@@ -40,19 +47,75 @@ module Tumblr
       get(url, params)
     end
 
+    # Get post of given ID from blog
+    def get_post(blog_name, post_id, options = {})
+      validate_options([:post_format], options)
+      get(blog_path(blog_name, "posts/#{post_id}"), options)
+    end
+
+    # Get notes for post of given ID
+    def notes(blog_name, post_id=nil, options = {})
+      validate_options([:id, :before_timestamp, :mode], options)
+      options[:id] ||= post_id
+      get(blog_path(blog_name, 'notes'), options)
+    end
+
+    # Get queued posts from blog (if authorized)
     def queue(blog_name, options = {})
       validate_options([:limit, :offset], options)
       get(blog_path(blog_name, 'posts/queue'), options)
     end
 
+    # Reorder blog's queue (if authorized)
+    def reorder_queue(blog_name, options = {})
+      validate_options([:post_id, :insert_after], options)
+      post(blog_path(blog_name, 'posts/queue/reorder'), options)
+    end
+
+    # Shuffle blog's queue (if authorized)
+    def shuffle_queue(blog_name)
+      post(blog_path(blog_name, 'posts/queue/shuffle'))
+    end
+
+    # Get drafts posts from blog (if authorized)
     def draft(blog_name, options = {})
       validate_options([:limit, :before_id], options)
       get(blog_path(blog_name, 'posts/draft'), options)
     end
+    alias_method :drafts, :draft
 
+    # Get pending submissions posts from blog (if authorized)
     def submissions(blog_name, options = {})
       validate_options([:limit, :offset], options)
       get(blog_path(blog_name, 'posts/submission'), options)
+    end
+    alias_method :submission, :submissions
+
+    # Get notifications for blog (if authorized)
+    def notifications(blog_name, options = {})
+      validate_options([:before, :types], options)
+      get(blog_path(blog_name, 'notifications'), options)
+    end
+
+    # Get blogs blocked by blog (if authorized)
+    def blocks(blog_name, options = {})
+      validate_options([:limit, :offset], options)
+      get(blog_path(blog_name, 'blocks'), options)
+    end
+    alias_method :blocked, :blocks
+
+    # Block a blog (blockee_blog) from blocker_blog (if authorized)
+    def block(blocker_blog, blockee_blog=nil, options = {})
+      validate_options([:blocked_tumblelog, :post_id], options)
+      options[:blocked_tumblelog] ||= blockee_blog
+      post(blog_path(blocker_blog, 'blocks'), options)
+    end
+
+    # Unlock a blog (blockee_blog) from blocker_blog (if authorized)
+    def unblock(blocker_blog, blockee_blog=nil, options = {})
+      validate_options([:blocked_tumblelog, :anonymous_only], options)
+      options[:blocked_tumblelog] ||= blockee_blog
+      delete(blog_path(blocker_blog, 'blocks'), options)
     end
 
   end

--- a/lib/tumblr/post.rb
+++ b/lib/tumblr/post.rb
@@ -18,7 +18,7 @@ module Tumblr
       post(blog_path(blog_name, 'post/reblog'), options)
     end
 
-    def delete(blog_name, id)
+    def delete_post(blog_name, id)
       post(blog_path(blog_name, 'post/delete'), :id => id)
     end
 

--- a/lib/tumblr/request.rb
+++ b/lib/tumblr/request.rb
@@ -39,6 +39,27 @@ module Tumblr
       respond(response)
     end
 
+    # Performs put request
+    def put(path, params={})
+      if Array === params[:tags]
+        params[:tags] = params[:tags].join(',')
+      end
+      response = connection.put do |req|
+        req.url path
+        req.body = params unless params.empty?
+      end
+      respond(response)
+    end
+
+    # Performs delete request
+    def delete(path, params={})
+      response = connection.delete do |req|
+        req.url path
+        req.body = params unless params.empty?
+      end
+      respond(response)
+    end
+
     def respond(response)
       if [201, 200].include?(response.status)
         response.body['response']

--- a/lib/tumblr/user.rb
+++ b/lib/tumblr/user.rb
@@ -37,5 +37,22 @@ module Tumblr
       post('v2/user/unlike', :id => id, :reblog_key => reblog_key)
     end
 
+    def filtered_content
+      get('v2/user/filtered_content')
+    end
+    alias_method :get_filtered_content, :filtered_content
+
+    def add_filtered_content(filtered_strings=nil, options={})
+      validate_options([:filtered_content], options)
+      options[:filtered_content] ||= filtered_strings
+      post('v2/user/filtered_content', options)
+    end
+
+    def delete_filtered_content(filtered_strings, options={})
+      validate_options([:filtered_content], options)
+      options[:filtered_content] ||= filtered_strings
+      delete('v2/user/filtered_content', options)
+    end
+
   end
 end

--- a/spec/examples/blog_spec.rb
+++ b/spec/examples/blog_spec.rb
@@ -359,24 +359,24 @@ describe Tumblr::Blog do
     end
   end # describe :block
 
-  # describe :unblock do
-  #   context 'with invalid parameters' do
-  #     it 'should raise an error' do
-  #       expect(lambda {
-  #         client.unblock blog_name, other_blog_name, not: 'an option'
-  #       }).to raise_error ArgumentError
-  #     end
-  #   end
+  describe :unblock do
+    context 'with invalid parameters' do
+      it 'should raise an error' do
+        expect(lambda {
+          client.unblock blog_name, other_blog_name, not: 'an option'
+        }).to raise_error ArgumentError
+      end
+    end
 
-  #   context 'with valid parameters' do
-  #     before do
-  #       expect(client).to receive(:post).once.with("v2/blog/#{blog_name}/blocks", blocked_tumblelog: other_blog_name).and_return('response')
-  #     end
-  #     it 'should construct the request properly' do
-  #       r = client.unblock blog_name, other_blog_name
-  #       expect(r).to eq('response')
-  #     end
-  #   end
-  # end # describe :unblock
+    context 'with valid parameters' do
+      before do
+        expect(client).to receive(:delete).once.with("v2/blog/#{blog_name}/blocks", blocked_tumblelog: other_blog_name).and_return('response')
+      end
+      it 'should construct the request properly' do
+        r = client.unblock blog_name, other_blog_name
+        expect(r).to eq('response')
+      end
+    end
+  end # describe :unblock
 
 end

--- a/spec/examples/blog_spec.rb
+++ b/spec/examples/blog_spec.rb
@@ -270,6 +270,113 @@ describe Tumblr::Blog do
 
     end
 
-  end
+  end # [:queue, :draft, :submissions].each
+
+  describe :reorder_queue do
+    context 'with invalid parameters' do
+      it 'should raise an error' do
+        expect(lambda {
+          client.reorder_queue blog_name, not: 'an option'
+        }).to raise_error ArgumentError
+      end
+    end
+
+    context 'with valid parameters' do
+      before do
+        expect(client).to receive(:post).once.with("v2/blog/#{blog_name}/posts/queue/reorder", post_id: 1, insert_after: 2).and_return('response')
+      end
+      it 'should construct the request properly' do
+        r = client.reorder_queue blog_name, post_id: 1, insert_after: 2
+        expect(r).to eq('response')
+      end
+    end
+  end # describe :reorder_queue
+
+  describe :shuffle_queue do
+    it 'should construct the request properly' do
+      expect(client).to receive(:post).once.with("v2/blog/#{blog_name}/posts/queue/shuffle").and_return('response')
+      r = client.shuffle_queue blog_name
+      expect(r).to eq('response')
+    end
+  end # describe :shuffle_queue
+
+  describe :notifications do
+    context 'with invalid parameters' do
+      it 'should raise an error' do
+        expect(lambda {
+          client.notifications blog_name, not: 'an option'
+        }).to raise_error ArgumentError
+      end
+    end
+
+    context 'with valid parameters' do
+      it 'should construct the request properly' do
+        timestamp = Time.now.to_i
+        expect(client).to receive(:get).once.with("v2/blog/#{blog_name}/notifications", before: timestamp).and_return('response')
+        r = client.notifications blog_name, before: timestamp
+        expect(r).to eq('response')
+      end
+    end
+  end # describe :notifications
+
+  describe :blocks do
+    context 'with invalid parameters' do
+      it 'should raise an error' do
+        expect(lambda {
+          client.blocks blog_name, not: 'an option'
+        }).to raise_error ArgumentError
+      end
+    end
+
+    context 'with valid parameters' do
+      before do
+        expect(client).to receive(:get).once.with("v2/blog/#{blog_name}/blocks", limit: 1).and_return('response')
+      end
+      it 'should construct the request properly' do
+        r = client.blocks blog_name, limit: 1
+        expect(r).to eq('response')
+      end
+    end
+  end # describe :blocks
+
+  describe :block do
+    context 'with invalid parameters' do
+      it 'should raise an error' do
+        expect(lambda {
+          client.block blog_name, other_blog_name, not: 'an option'
+        }).to raise_error ArgumentError
+      end
+    end
+
+    context 'with valid parameters' do
+      before do
+        expect(client).to receive(:post).once.with("v2/blog/#{blog_name}/blocks", blocked_tumblelog: other_blog_name).and_return('response')
+      end
+      it 'should construct the request properly' do
+        r = client.block blog_name, other_blog_name
+        expect(r).to eq('response')
+      end
+    end
+  end # describe :block
+
+  # describe :unblock do
+  #   context 'with invalid parameters' do
+  #     it 'should raise an error' do
+  #       expect(lambda {
+  #         client.unblock blog_name, other_blog_name, not: 'an option'
+  #       }).to raise_error ArgumentError
+  #     end
+  #   end
+
+  #   context 'with valid parameters' do
+  #     before do
+  #       expect(client).to receive(:post).once.with("v2/blog/#{blog_name}/blocks", blocked_tumblelog: other_blog_name).and_return('response')
+  #     end
+  #     it 'should construct the request properly' do
+  #       r = client.unblock blog_name, other_blog_name
+  #       expect(r).to eq('response')
+  #     end
+  #   end
+  # end # describe :unblock
 
 end

--- a/spec/examples/blog_spec.rb
+++ b/spec/examples/blog_spec.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 describe Tumblr::Blog do
 
   let(:blog_name) { 'seejohnrun.tumblr.com' }
+  let(:post_id) { 45693025 }
+  let(:other_blog_name) { 'staff' }
   let(:consumer_key) { 'ckey' }
   let(:client) do
     Tumblr::Client.new :consumer_key => consumer_key
@@ -89,6 +91,46 @@ describe Tumblr::Blog do
 
   end
 
+  describe :blow_following do
+    context 'with invalid parameters' do
+      it 'should raise an error' do
+        expect(lambda {
+          client.blog_following blog_name, :not => 'an option'
+        }).to raise_error ArgumentError
+      end
+    end
+
+    context 'with valid parameters' do
+      before do
+        expect(client).to receive(:get).once.with("v2/blog/#{blog_name}/following", limit: 1).and_return('response')
+      end
+      it 'should construct the request properly' do
+        r = client.blog_following blog_name, limit: 1
+        expect(r).to eq 'response'
+      end
+    end
+  end # describe :blog_following
+
+  describe :followed_by do
+    context 'with invalid parameters' do
+      it 'should raise an error' do
+        expect(lambda {
+          client.followed_by blog_name, other_blog_name, :not => 'an option'
+        }).to raise_error ArgumentError
+      end
+    end
+
+    context 'with valid parameters' do
+      before do
+        expect(client).to receive(:get).once.with("v2/blog/#{blog_name}/followed_by", query: other_blog_name).and_return('response')
+      end
+      it 'should construct the request properly' do
+        r = client.followed_by blog_name, other_blog_name
+        expect(r).to eq 'response'
+      end
+    end
+  end # describe :followed_by
+
   describe :blog_likes do
 
     context 'with invalid parameters' do
@@ -155,6 +197,46 @@ describe Tumblr::Blog do
     end
 
   end
+
+  describe :get_post do
+    context 'with invalid parameters' do
+      it 'should raise an error' do
+        expect(lambda {
+          client.get_post blog_name, post_id, not: 'an option'
+        }).to raise_error ArgumentError
+      end
+    end
+
+    context 'with valid parameters' do
+      before do
+        expect(client).to receive(:get).once.with("v2/blog/#{blog_name}/posts/#{post_id}", {}).and_return('response')
+      end
+      it 'should construct the request properly' do
+        r = client.get_post blog_name, post_id
+        expect(r).to eq('response')
+      end
+    end
+  end # describe :get_post
+
+  describe :notes do
+    context 'with invalid parameters' do
+      it 'should raise an error' do
+        expect(lambda {
+          client.notes blog_name, post_id, not: 'an option'
+        }).to raise_error ArgumentError
+      end
+    end
+
+    context 'with valid parameters' do
+      before do
+        expect(client).to receive(:get).once.with("v2/blog/#{blog_name}/notes", id: post_id).and_return('response')
+      end
+      it 'should construct the request properly' do
+        r = client.notes blog_name, post_id
+        expect(r).to eq('response')
+      end
+    end
+  end # describe :notes
 
   # These are all just lists of posts with pagination
   [:queue, :draft, :submissions].each do |type|

--- a/spec/examples/post_spec.rb
+++ b/spec/examples/post_spec.rb
@@ -20,7 +20,7 @@ describe Tumblr::Post do
       end
 
       it 'should setup a delete properly' do
-        client.delete blog_name, post_id
+        client.delete_post blog_name, post_id
       end
 
     end

--- a/spec/examples/user_spec.rb
+++ b/spec/examples/user_spec.rb
@@ -4,6 +4,7 @@ describe Tumblr::User do
 
   let(:client) { Tumblr::Client.new }
 
+
   describe :info do
 
     it 'should make the request properly' do
@@ -109,6 +110,30 @@ describe Tumblr::User do
 
     end
 
+  end  
+
+  describe :filtered_content do
+    it 'should make the reqest properly' do
+      expect(client).to receive(:get).with("v2/user/filtered_content").and_return('response')
+      r = client.filtered_content
+      expect(r).to eq('response')
+    end
+  end
+
+  describe :add_filtered_content do
+    it 'should make the reqest properly' do
+      expect(client).to receive(:post).with("v2/user/filtered_content", filtered_content: ['str']).and_return('response')
+      r = client.add_filtered_content ['str']
+      expect(r).to eq('response')
+    end
+  end
+
+  describe :delete_filtered_content do
+    it 'should make the reqest properly' do
+      expect(client).to receive(:delete).with("v2/user/filtered_content", filtered_content: ['str']).and_return('response')
+      r = client.delete_filtered_content ['str']
+      expect(r).to eq('response')
+    end
   end
 
 end

--- a/tumblr_client.gemspec
+++ b/tumblr_client.gemspec
@@ -2,8 +2,8 @@
 require File.join(File.dirname(__FILE__), 'lib/tumblr/version')
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'faraday', '~> 0.9.0'
-  gem.add_dependency 'faraday_middleware', '~> 0.9'
+  gem.add_dependency 'faraday', '~> 1.0'
+  gem.add_dependency 'faraday_middleware', '~> 1.0'
   gem.add_dependency 'json'
   gem.add_dependency 'simple_oauth'
   gem.add_dependency 'oauth'


### PR DESCRIPTION
Added support and tests for the following API endpoints:

- blog: /blocks, /followed_by, /following, /notes, /notifications, /posts/{post_id} (GET request only), /posts/queue/reorder, /posts/queue/shuffle

- user: /filtered_content