### PR TITLE
Enable GitHub workflows-based CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+# yamllint disable rule:line-length
+# yamllint disable rule:braces
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  tests:
+    name: Testing with Ruby ${{ matrix.ruby-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version:
+          - '2.6'
+          - '2.7'
+          - '3.0'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: |
+          bundle exec rspec spec

--- a/.github/workflows/validate_yaml.yaml
+++ b/.github/workflows/validate_yaml.yaml
@@ -1,0 +1,20 @@
+# yamllint disable rule:line-length
+
+name: YAML Validation
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  validate-yaml:
+    name: Validate YAML
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run YAML linter
+        run: |
+          find . -path \*/vendor -prune -false -o -name \*.y*ml | xargs yamllint -d relaxed

--- a/tumblr_client.gemspec
+++ b/tumblr_client.gemspec
@@ -2,8 +2,8 @@
 require File.join(File.dirname(__FILE__), 'lib/tumblr/version')
 
 Gem::Specification.new do |gem|
-  gem.add_dependency 'faraday', '~> 0.9.0'
-  gem.add_dependency 'faraday_middleware', '~> 0.9'
+  gem.add_dependency 'faraday', '~> 1.0'
+  gem.add_dependency 'faraday_middleware', '~> 1.0'
   gem.add_dependency 'json'
   gem.add_dependency 'simple_oauth'
   gem.add_dependency 'oauth'


### PR DESCRIPTION
You can see how it looks like here: https://github.com/sanmai/tumblr_client/pull/1

![](https://user-images.githubusercontent.com/139488/145736469-5a7303f5-c3ae-4c98-94b6-7efbea28bc6c.png)

Although [adding Ruby 1.9 and 2.0 to the build matrix is not impossible](https://github.com/sanmai/tumblr_client/pull/2/files), they look too antiquated to make the time required to make them work worthwhile. 
